### PR TITLE
Add bios to DB and delete bios from DB when channel is purged

### DIFF
--- a/bot/cogs/bio.py
+++ b/bot/cogs/bio.py
@@ -1,0 +1,25 @@
+import discord
+from discord.ext import commands
+from extras.IDS import cafe
+
+class bio(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command()
+    async def bio(self, ctx, member: discord.Member=None):
+        """Posts someones bio."""
+        data = await self.bot.bio.find(member.id)
+        if not data:
+            if member == ctx.author:
+                return await ctx.send("You don't have a bio stored.")
+            else:
+                return await ctx.send("They don't have a bio stored.")
+        
+        bio_channel = self.bot.get_channel(cafe.friends.bio)
+        msg = await bio_channel.fetch_message(data["msg_id"])
+
+        view = discord.ui.View()
+        view.add_item(discord.ui.Button(label="Go to bio post", url=msg.jump_url))
+
+        await ctx.send(discord.utils.escape_mentions(f"**Bio for {member.name}**\n{data['bio']}"), view=view)

--- a/bot/cogs/react.py
+++ b/bot/cogs/react.py
@@ -1,3 +1,4 @@
+import discord
 from discord.ext import commands
 import sys
 sys.path.append('..')
@@ -72,14 +73,18 @@ class auto_react(commands.Cog):
       return
     
     if payload.emoji.id == 973078040336797696:
-      """await self.bot.bio.upsert(
+      await self.bot.bio.upsert(
           {
-            "_id":msg.author.id,
-            "bio":msg.content
+            "_id": msg.author.id,
+            "bio": str(msg.content)
           }
-        )"""
+        )
+      view = discord.ui.View()
+      view.add_item(discord.ui.Button(label="Go to bio", url=msg.jump_url)) # adds a button that jumps to their bio
+      
+      await msg.author.send("Your bio has been stored!", view=view)
         
-        await msg.clear_reactions()
+      await msg.clear_reactions()
         
     if str(payload.emoji) !="📥":
       return

--- a/bot/cogs/react.py
+++ b/bot/cogs/react.py
@@ -70,6 +70,9 @@ class auto_react(commands.Cog):
       return
     
     if payload.emoji.id == 973078040336797696 and channel.id == ID.cafe.friends.bio:
+      if payload.member.id != msg.author.id:
+        return # they haven't reacted to their own message.
+
       await self.bot.bio.upsert(
           {
             "_id": msg.author.id,

--- a/bot/cogs/react.py
+++ b/bot/cogs/react.py
@@ -76,7 +76,8 @@ class auto_react(commands.Cog):
       await self.bot.bio.upsert(
           {
             "_id": msg.author.id,
-            "bio": str(msg.content)
+            "bio": str(msg.content),
+            "msg_id": msg.id
           }
         )
       view = discord.ui.View()

--- a/bot/cogs/react.py
+++ b/bot/cogs/react.py
@@ -69,10 +69,7 @@ class auto_react(commands.Cog):
     if guild.id != ID.server.cafe:
       return
     
-    if channel.id != cafe.friends.connect:
-      return
-    
-    if payload.emoji.id == 973078040336797696:
+    if payload.emoji.id == 973078040336797696 and channel.id == ID.cafe.friends.bio:
       await self.bot.bio.upsert(
           {
             "_id": msg.author.id,
@@ -85,6 +82,9 @@ class auto_react(commands.Cog):
       await msg.author.send("Your bio has been stored!", view=view)
         
       await msg.clear_reactions()
+    
+    if channel.id != cafe.friends.connect:
+      return
         
     if str(payload.emoji) !="📥":
       return

--- a/bot/cogs/sticky.py
+++ b/bot/cogs/sticky.py
@@ -31,12 +31,14 @@ class sticky(commands.Cog):
     elif msg.channel.id == cafe.friends.bio:
       cha = self.bot.get_channel(cafe.friends.bio) or await self.bot.fetch_channel(cafe.friends.bio)   
       await cha.purge(limit=2, check=is_me)
+      
       await self.bot.bio.upsert(
-        {
-          "_id": msg.author.id,
-          "bio": str(msg.content)
-        }
-      )
+          {
+            "_id": msg.author.id,
+            "bio": str(msg.content),
+            "msg_id": msg.id
+          }
+        )
       
       await cha.send(b.bt)
     

--- a/bot/cogs/sticky.py
+++ b/bot/cogs/sticky.py
@@ -31,13 +31,13 @@ class sticky(commands.Cog):
     elif msg.channel.id == cafe.friends.bio:
       cha = self.bot.get_channel(cafe.friends.bio) or await self.bot.fetch_channel(cafe.friends.bio)   
       await cha.purge(limit=2, check=is_me)
-      """await self.bot.bio.upsert(
+      await self.bot.bio.upsert(
         {
-          "_id":msg.author.id,
-          "bio":msg.content
+          "_id": msg.author.id,
+          "bio": str(msg.content)
         }
       )
-      """
+      
       await cha.send(b.bt)
     
     elif msg.channel.id == cafe.chat.dm:

--- a/bot/main.py
+++ b/bot/main.py
@@ -59,7 +59,10 @@ async def purge():
     await cha.purge(limit=500)
     if channel == cafe.friends.connect:
       await cha.send("Connect Post Example:\n```Status:\nMood:\nTopics of interest right now:```\n\nMust be text only, you can delete your status at any time!")
-  bot.db.inbox.drop()
+  
+  entries = await bot.inbox.get_all()
+  for entry in entries:
+    await bot.inbox.delete(entry["_id"])
   
 @bot.event
 async def on_member_join(mem):

--- a/bot/main.py
+++ b/bot/main.py
@@ -3,7 +3,7 @@ import cogs.sticky as sticky
 import cogs.react as react
 import cogs.bingus as BINGUS_MEME
 import cogs.special_things as SPECIAL
-
+import cogs.bio as bio
 #async_run---------------------------------------------------------------------------------------
 import asyncio
 def run(run):
@@ -105,6 +105,7 @@ async def main_start(run):
         await bot.add_cog(BINGUS_MEME.bingus(bot))
         await bot.add_cog(sticky.sticky(bot))
         await bot.add_cog(react.auto_react(bot))
+        await bot.add_cog(bio.bio(bot))
         await bot.start(str(key)) 
 
         


### PR DESCRIPTION
Adds the following:
* Adds bios to the database when an emoji is reacted to a bio
* Only adds the bio if it's in the bio channel
* When a bio is added, it DMs the user with a button that jumps to their bio.
* Deletes all connect posts from the database every 4 hours.
* Bio command (in separate cog)
* If someone reacts to someone else's bio, it won't do anything. 